### PR TITLE
fix(typo): edited swaggify command to swaggiffy

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ npx swaggify generate:config
 Generate the spec file only.
 
 ```bash
-npx swaggify generate:spec
+npx swaggiffy generate:spec
 ```
 
 ### Instantiate Swaggify


### PR DESCRIPTION
## What the PR do

The PR fixes the guide typo

## PR description

The current command in the guide
```bash
npx swaggify generate:spec
```
Throws a command not found error.

The PR fixes the command to

```bash
npx swaggiffy generate:spec
```

## How to manually test 

Run 
```bash
npx swaggiffy generate:spec
```

**expected behavior ** : It will throw a command not found an error

Run 
```bash
npx swaggiffy generate:spec
```
**expected behavior** : should generate config